### PR TITLE
fix word of day calc to ignore time

### DIFF
--- a/src/lib/words.ts
+++ b/src/lib/words.ts
@@ -14,6 +14,8 @@ export const isWinningWord = (word: string) => {
 
 export const getWordOfDay = () => {
   const now = new Date()
+  now.setDate(now.getDate() + 1)
+  now.setHours(0, 0, 0, 0)
   const then = new Date(now.getFullYear(), 0, 1).getTime()
   const index = Math.ceil((now.getTime() - then) / 86400000)
   return {


### PR DESCRIPTION
The word of the day index calculation returned the previous day's word between the hours of 00:00 and 01:00 (BST)

This PR fixes that by ignoring the current time and only considers the current date in the calculation.

As a consequence, we also need to increase the current date by 1 in order to not break the word selection for the day immediately following the merge of this PR.